### PR TITLE
ci: pin semver

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: lowlighter/metrics@latest
+      - uses: lowlighter/metrics@3.33
         with:
           # Your GitHub token
           # The following scopes are required:


### PR DESCRIPTION
Pinning the semver of the previous release to:
 - track specific non-mutable identities
 - see an update proposed