### PR TITLE
fix: switch to hxreborn PR to fix lowlighter bitrot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: lowlighter/metrics@3.34
+      - uses: hxreborn/metrics@7d4d44c0e63958b38deed2348b19ce98bdaa405b # lowlighter/metrics@3.34 ++
         with:
           # Your GitHub token
           # The following scopes are required:


### PR DESCRIPTION
Lowlighter hasn't been maintaining `metrics` so there's been fork activity; lishaduck is forking, but hxreborn has a part fix for the issue impacting the page, so I'm pinning to hxreborn commit until an update there, or back at low lighter, or lishaduck's work gets a solid update.